### PR TITLE
don't assert when maxImageCount cap is 0

### DIFF
--- a/src/graphics/renderervk.rs
+++ b/src/graphics/renderervk.rs
@@ -1129,7 +1129,7 @@ impl RendererVkSwapchain {
     ///
     fn new(device: &RendererVkDevice, surface: &RendererVkSurface, image_count: u32) -> RendererVkSwapchain {
         debug_assert!(image_count >= surface.capabilities.minImageCount);
-        debug_assert!(image_count <= surface.capabilities.maxImageCount);
+        debug_assert!(image_count <= surface.capabilities.maxImageCount || surface.capabilities.maxImageCount == 0);
 
         let layers = 1; // Non-stereoscopic
         debug_assert!(layers <= surface.capabilities.maxImageArrayLayers);


### PR DESCRIPTION
WSI spec:

> maxImageCount is the maximum number of images the specified device supports for a swapchain created for the surface, and will be either 0, or greater than or equal to minImageCount. A value of 0 means that there is no limit on the number of images, though there may be limits related to the total amount of memory used by presentable images.