### PR TITLE
add newline after enabling GL_KHR_vulkan_glsl

### DIFF
--- a/src/graphics/shaderglsl.rs
+++ b/src/graphics/shaderglsl.rs
@@ -622,7 +622,7 @@ fn compile_glsl(name: &str, source_names: &Vec<String>, glsl: &str, shader_stage
         preprocessed = re.replace_all(glsl, "layout(").to_string();
     } else {
         preprocessed = glsl.to_string();
-        preamble = preamble + &"#extension GL_KHR_vulkan_glsl : enable"
+        preamble = preamble + &"#extension GL_KHR_vulkan_glsl : enable\n"
     }
 
     unsafe {


### PR DESCRIPTION
Without it, the generated shaders looks like this

```
#version 450 core
#extension GL_KHR_vulkan_glsl : enable/*
 Copyright (c) 2016-2017 Bruce Stenning. All rights reserved.
[...]
```

and mesa doesn't want to compile it like that: `0:2(39): error: syntax error, unexpected '/', expecting EOL`